### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Burrito-bot_OLD/README.md
+++ b/Burrito-bot_OLD/README.md
@@ -1,4 +1,4 @@
-#Burrito Bison bot
+# Burrito Bison bot
 
 *Edit (05-19-13): This is years old. Keeping it for time capsule  purposes..*   
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-##Burrito Bot
+## Burrito Bot
 
 <p align="center">
 	<img src="https://github.com/Audionautics/Burrito-Bot/blob/master/doc_images/bot_img.png?raw=true"/>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
